### PR TITLE
date_created & date_modified 

### DIFF
--- a/src/main/java/policycompass/fcmmanager/controllers/FCMModels.java
+++ b/src/main/java/policycompass/fcmmanager/controllers/FCMModels.java
@@ -674,7 +674,7 @@ public class FCMModels {
 		concept[17].setTitle("Initiative 1 (e-workflow introduction)");
 		concept[18].setTitle("Initiative 2 (number of e-services)");
 		concept[19].setTitle("Initiative 3 (Penetration rate of broadband nets)");
-		concept[20].setTitle("Initiative 4 (citizenâ€™s e-skills improvement)");
+		concept[20].setTitle("Initiative 4 (citizen's e-skills improvement)");
 		concept[21].setTitle("Government spending");
 		concept[22].setTitle("Speed of public services delivery");
 		concept[23].setTitle("Level of public services accessibility");

--- a/src/main/java/policycompass/fcmmanager/controllers/FCMModels.java
+++ b/src/main/java/policycompass/fcmmanager/controllers/FCMModels.java
@@ -88,8 +88,8 @@ public class FCMModels {
 			model.setDescription(jsonModel.getJSONObject("data").get("ModelDesc").toString());
 			model.setKeywords(jsonModel.getJSONObject("data").get("ModelKeywords").toString());
 			model.setUserID(Integer.parseInt(jsonModel.getJSONObject("data").get("userID").toString()));
-			model.setDateAddedtoPC(date1);
-			model.setDateModified(date1);
+			model.setdate_created(date1);
+			model.setdate_modified(date1);
 			model.setUserPath(userPath);
 			model.setis_draft(Boolean.parseBoolean(jsonModel.getJSONObject("data").get("isDraft").toString()));
 			model.setDerivedFromId(Integer.parseInt(jsonModel.getJSONObject("data").get("derivedFromId").toString()));
@@ -296,7 +296,7 @@ public class FCMModels {
 			throw new NotAuthorizedException("This model has been created by another user.");//Throwing unauthorized message
 		}
 
-		model.setDateModified(date1);
+		model.setdate_modified(date1);
 		try{
 			model.setTitle(jsonModel.getJSONObject("data").getJSONObject("model").get("title").toString());
 			model.setDescription(jsonModel.getJSONObject("data").getJSONObject("model").get("description").toString());
@@ -649,8 +649,8 @@ public class FCMModels {
 		for (int i = 0; i < 2; i++) {
 			model[i].setId(modelID + i);
 			model[i].setUserID(1);
-			model[i].setDateAddedtoPC(date1);
-			model[i].setDateModified(date1);
+			model[i].setdate_created(date1);
+			model[i].setdate_modified(date1);
 			model[i].setViewsCount(0);
 		}
 
@@ -674,7 +674,7 @@ public class FCMModels {
 		concept[17].setTitle("Initiative 1 (e-workflow introduction)");
 		concept[18].setTitle("Initiative 2 (number of e-services)");
 		concept[19].setTitle("Initiative 3 (Penetration rate of broadband nets)");
-		concept[20].setTitle("Initiative 4 (citizen’s e-skills improvement)");
+		concept[20].setTitle("Initiative 4 (citizenâ€™s e-skills improvement)");
 		concept[21].setTitle("Government spending");
 		concept[22].setTitle("Speed of public services delivery");
 		concept[23].setTitle("Level of public services accessibility");

--- a/src/main/java/policycompass/fcmmanager/models/FCMModel.java
+++ b/src/main/java/policycompass/fcmmanager/models/FCMModel.java
@@ -1,7 +1,8 @@
 package policycompass.fcmmanager.models;
 
 import java.util.Date;
-
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -20,10 +21,11 @@ public class FCMModel {
 	private String Keywords;
 	@Column(name = "UserID", nullable = false)
 	private int UserID;
-	@Column(name = "DateAddedtoPC", nullable = false)
-	private Date DateAddedtoPC;
-	@Column(name = "DateModified", nullable = false)
-	private Date DateModified;
+
+	@Column(name = "date_created", nullable = false)
+	private Date Date_Created;
+	@Column(name = "date_modified", nullable = false)
+	private Date Date_Modified;
 	@Column(name = "ViewsCount", nullable = false)
 	private int ViewsCount;
 	@Column(name = "UserPath", nullable = true)
@@ -72,11 +74,18 @@ public class FCMModel {
 	public int getUserID() { return UserID; }
 	public void setUserID(int userid) { this.UserID = userid; }
 
-	public Date getDateAddedtoPC() { return DateAddedtoPC; }
-	public void setDateAddedtoPC(Date dateaddedtopc) { this.DateAddedtoPC = dateaddedtopc; }
+	public String getdate_created() {
+		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+		return sdf.format(Date_Created);
+	}
+	public void setdate_created(Date date_created) { this.Date_Created = date_created; }
 
-	public Date getDateModified() { return DateModified; }
-	public void setDateModified(Date datemodified) { this.DateModified = datemodified; }
+	public String getdate_modified() {
+		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+		return sdf.format(Date_Modified); }
+	public void setdate_modified(Date date_modified) { this.Date_Modified = date_modified; }
 
 	public int getViewsCount() { return ViewsCount; }
 	public void setViewsCount(int viewscount) { this.ViewsCount = viewscount; }

--- a/src/main/java/policycompass/fcmmanager/models/FCMModelDetail.java
+++ b/src/main/java/policycompass/fcmmanager/models/FCMModelDetail.java
@@ -55,7 +55,7 @@ public class FCMModelDetail {
 	public void setConceptindividuals(List<FCMConceptIndividual> conceptindividuals) {
 		this.conceptindividuals = conceptindividuals;
 	}
-/*
+
 	public FCMModelDetail(int modelID) {
 		Session session = HibernateUtil.getSessionFactory().openSession();
 		Query query = session.createQuery("from fcmmanager_models where id= :id");
@@ -94,7 +94,6 @@ public class FCMModelDetail {
 		session.clear();
 		session.close();
 	}
-        */
 
 	public FCMModelDetail(String userPath, int modelID) {
 		Session session = HibernateUtil.getSessionFactory().openSession();

--- a/src/main/java/policycompass/fcmmanager/services/FCMModelService.java
+++ b/src/main/java/policycompass/fcmmanager/services/FCMModelService.java
@@ -147,7 +147,11 @@ public class FCMModelService {
 	@Consumes({MediaType.APPLICATION_JSON})
 	@Produces({MediaType.APPLICATION_JSON})
 	public Response runImpactAnaylsis(@PathParam("id") int id, JSONObject fcmmodel) {
-		return Response.ok(pcjfcm.runImpactAnalysis(id, fcmmodel)).build();
+		Response rb = null;
+		try{
+			rb = Response.ok(pcjfcm.runImpactAnalysis(id, fcmmodel)).build();
+		}catch(Exception ex){}
+		return rb;
 //        return Response.ok(fcmmodel).build();
 	}
 }

--- a/src/main/java/policycompass/fcmmanager/simulation/pcjfcm.java
+++ b/src/main/java/policycompass/fcmmanager/simulation/pcjfcm.java
@@ -1,9 +1,12 @@
 package policycompass.fcmmanager.simulation;
 
 import java.text.DecimalFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
@@ -24,6 +27,7 @@ import policycompass.fcmmanager.models.FCMConcept;
 import policycompass.fcmmanager.models.FCMConceptIndividual;
 import policycompass.fcmmanager.models.FCMConnection;
 import policycompass.fcmmanager.models.FCMModel;
+import policycompass.fcmmanager.models.FCMModelDetail;
 import policycompass.fcmmanager.models.FCMSimulationConcept;
 import policycompass.fcmmanager.models.FCMSimulationConnection;
 import policycompass.fcmmanager.models.FCMSimulationDetail;
@@ -99,12 +103,17 @@ public class pcjfcm {
 		session.beginTransaction();
 
 		try {
-			modelID = Integer
-					.parseInt(jsonModel.getJSONObject("data").getJSONObject("model").get("ModelID").toString());
+			modelID = Integer.parseInt(jsonModel.getJSONObject("data").getJSONObject("model").get("ModelID").toString());
+			FCMModelDetail modelDetails= new FCMModelDetail(modelID);
+			SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+			sdf.setTimeZone(TimeZone.getDefault());
+
 			model.setId(modelID);
 			model.setTitle(jsonModel.getJSONObject("data").getJSONObject("model").get("title").toString());
 			model.setDescription(jsonModel.getJSONObject("data").getJSONObject("model").get("description").toString());
 			model.setKeywords(jsonModel.getJSONObject("data").getJSONObject("model").get("keywords").toString());
+			model.setdate_created(sdf.parse(modelDetails.getModel().getdate_created()));
+			model.setdate_modified(sdf.parse(modelDetails.getModel().getdate_modified()));
 
 			activatorID = Integer.parseInt(jsonModel.getJSONObject("data").get("activatorId").toString());
 
@@ -342,7 +351,7 @@ public class pcjfcm {
 		return (FCMSimulation);
 	}
 
-	public static FCMSimulationDetail runImpactAnalysis(int id, JSONObject jsonModel) {
+	public static FCMSimulationDetail runImpactAnalysis(int id, JSONObject jsonModel) throws ParseException {
 		FCMModel model = new FCMModel();
 		List<List<FCMSimulationConcept>> listSimulationConcept = new ArrayList<List<FCMSimulationConcept>>();
 		List<FCMSimulationConcept> simulationConcept = new ArrayList<FCMSimulationConcept>();
@@ -365,12 +374,17 @@ public class pcjfcm {
 		af.setIncludePreviousOutput(false);
 
 		try {
-			modelID = Integer
-					.parseInt(jsonModel.getJSONObject("data").getJSONObject("model").get("ModelID").toString());
+			modelID = Integer.parseInt(jsonModel.getJSONObject("data").getJSONObject("model").get("ModelID").toString());
+			FCMModelDetail modelDetails= new FCMModelDetail(modelID);
+			SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+			sdf.setTimeZone(TimeZone.getDefault());
+
 			model.setId(modelID);
 			model.setTitle(jsonModel.getJSONObject("data").getJSONObject("model").get("title").toString());
 			model.setDescription(jsonModel.getJSONObject("data").getJSONObject("model").get("description").toString());
 			model.setKeywords(jsonModel.getJSONObject("data").getJSONObject("model").get("keywords").toString());
+			model.setdate_created(sdf.parse(modelDetails.getModel().getdate_created()));
+			model.setdate_modified(sdf.parse(modelDetails.getModel().getdate_modified()));
 
 			JSONArray concepts = jsonModel.getJSONObject("data").getJSONArray("concepts");
 			for (int i = 0; i < concepts.length(); i++) {


### PR DESCRIPTION
policycompass/policycompass#676

Please run the below script, before build or deploy back-end application. Otherwise created and modified date of old models will be removed.

```
ALTER TABLE fcmmanager_models RENAME COLUMN dateaddedtopc TO date_created;
ALTER TABLE fcmmanager_models RENAME COLUMN datemodified TO date_modified;
```
@cbotsikas please confirm the output in the images below. 

![1](https://cloud.githubusercontent.com/assets/16784021/18672511/5e6a1778-7f40-11e6-866e-b4a7c2b70a3d.png)

![2](https://cloud.githubusercontent.com/assets/16784021/18672533/6e96bdcc-7f40-11e6-8f9f-5f382dbf74d6.png)



